### PR TITLE
Allow container to run as a non-root user

### DIFF
--- a/couchbase-server/Dockerfile
+++ b/couchbase-server/Dockerfile
@@ -50,9 +50,12 @@ RUN groupadd -g1000 couchbase && \
 
 # Install couchbase
 RUN rpm --install $CB_RELEASE_URL/$PROD_VERSION/$CB_PACKAGE
+RUN chmod -R o+rwx /opt/couchbase/etc
+RUN chmod -R o+rwx /opt/couchbase/var
 
 # Add runit script for couchbase-server
 COPY scripts/run /etc/service/couchbase-server/run
+RUN chmod g+rwx /etc/service/couchbase-server
 
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
@@ -77,6 +80,8 @@ LABEL run="docker run -d --privileged -p 8091:8091 --restart always \
     --name NAME IMAGE"
 
 COPY scripts/entrypoint.sh /
+
+USER 1000
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 

--- a/couchbase-server/Dockerfile.testing
+++ b/couchbase-server/Dockerfile.testing
@@ -53,9 +53,12 @@ RUN groupadd -g1000 couchbase && \
 
 # Install couchbase
 RUN rpm --install $CB_RELEASE_URL/$PROD_VERSION/$CB_PACKAGE
+RUN chmod -R o+rwx /opt/couchbase/etc
+RUN chmod -R o+rwx /opt/couchbase/var
 
 # Add runit script for couchbase-server
 COPY scripts/run /etc/service/couchbase-server/run
+RUN chmod g+rwx /etc/service/couchbase-server
 
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
@@ -87,6 +90,8 @@ LABEL run="docker run -d --privileged -p 8091:8091 --restart always \
     --name NAME IMAGE"
 
 COPY scripts/entrypoint-testing.sh /entrypoint.sh
+
+USER 1000
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 

--- a/couchbase-server/scripts/run
+++ b/couchbase-server/scripts/run
@@ -11,5 +11,4 @@ mkdir -p var/lib/couchbase \
          var/lib/couchbase/logs \
          var/lib/moxi
 
-chown -R couchbase:couchbase var
-exec chpst -ucouchbase  /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
+exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput


### PR DESCRIPTION
This resolves the issue of running containers as a non-root user. By
setting the user to 1000 we are guarenteed to start Couchbase as the
couchbase user. In Openshift deployments we can also run as a random
user (the USER command is ignored) by giving our Couchbase
installation and runit the ability to be executed and run by any user.