### PR TITLE
CBD-5174, fix SGW rhcc build.

### DIFF
--- a/scripts/build-rhcc-image.sh
+++ b/scripts/build-rhcc-image.sh
@@ -56,7 +56,7 @@ if [[ -z "$BLD_NUM" ]]; then
     echo "Build number of product (-b) is required"
     exit 1
 fi
-if [[ $BLD_NUM -lt 10 ]]; then
+if [[ ${PRODUCT} == "couchbase-server" && $BLD_NUM -lt 10 ]]; then
     echo "Please use complete internal build number, not ${BLD_NUM}"
     exit 1
 fi

--- a/sync-gateway/Dockerfile
+++ b/sync-gateway/Dockerfile
@@ -43,8 +43,10 @@ LABEL name="couchbase/sync-gateway" \
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Copy sample service config as the initial config
+RUN mkdir /etc/sync_gateway \
+    && cp /opt/couchbase-sync-gateway/examples/serviceconfig.json /etc/sync_gateway/config.json \
+    && chown -R sync_gateway:sync_gateway /etc/sync_gateway
 
 # Invoke the sync_gateway executable by default
 ENTRYPOINT ["sync_gateway"]


### PR DESCRIPTION
* add entrypoint.sh as we do w/ the dockerhub image
* use SGW's examples/serviceconfig.json as the default config so that we don't have to manually update it.
* change build-rhcc-image script to accommodate low bld_num from SGW

-Ming Ho