### PR TITLE
CBG-3613 run sync gateway in writeable directory

### DIFF
--- a/sync-gateway/Dockerfile.multiarch
+++ b/sync-gateway/Dockerfile.multiarch
@@ -60,6 +60,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/etc/sync_gateway/config.json"]
 
 USER sync_gateway
+WORKDIR /home/sync_gateway
 
 # Expose ports
 #  port 4984: public port, port 4985: admin port

--- a/sync-gateway/Dockerfile.x64
+++ b/sync-gateway/Dockerfile.x64
@@ -55,6 +55,7 @@ ENTRYPOINT ["sync_gateway"]
 CMD ["/etc/sync_gateway/config.json"]
 
 USER sync_gateway
+WORKDIR /home/sync_gateway
 
 # Expose ports
 #  port 4984: public port, port 4985: admin port


### PR DESCRIPTION
Ideally, sync gateway won't write any files here, but sometimes this happens. This behavior matches that of the systemd setup.