### PR TITLE
MB-71464 update SGW base image to ubi9. 

### DIFF
--- a/sync-gateway/Dockerfile.multiarch
+++ b/sync-gateway/Dockerfile.multiarch
@@ -1,5 +1,5 @@
 # Dockerfile to build the OpenShift image for sync-gateway
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 LABEL maintainer="build-team@couchbase.com"
 


### PR DESCRIPTION
Use ubi9/ubi-minimal as the base image for SGW.

-Ming